### PR TITLE
docs(README): update community involvement section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ The project includes the design of dragonfly services.
 
 ## Community
 
-Join the conversation and help the community.
+Join the conversation and help the community grow. Here are the ways to get involved:
 
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
 - **Github Discussions**: [Dragonfly Discussion Forum][discussion]
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
-- **Maintainer Group**: <dragonfly-maintainers@googlegroups.com>
+- **Mailing Lists**:
+  - **Developers**: <dragonfly-developers@googlegroups.com>
+  - **Maintainers**: <dragonfly-maintainers@googlegroups.com>
 - **Twitter**: [@dragonfly_oss](https://twitter.com/dragonfly_oss)
-- **DingTalk**: [22880028764](https://qr.dingtalk.com/action/joingroup?code=v1,k1,pkV9IbsSyDusFQdByPSK3HfCG61ZCLeb8b/lpQ3uUqI=&_dt_no_comment=1&origin=11)
+- **DingTalk Group**: `22880028764`
 
 ## Contributing
 


### PR DESCRIPTION
This pull request updates the community section of the `README.md` to make it more informative and organized. The changes clarify how users can get involved and improve the presentation of community contact options.

Community section improvements:

* Expanded the invitation to join the community by specifying ways to get involved and making the language more welcoming.
* Reorganized mailing list information under a new "Mailing Lists" subsection, separating developers and maintainers for clarity.
* Updated the DingTalk contact to clearly indicate it is a group and simplified its presentation.